### PR TITLE
Open directory after creating flag

### DIFF
--- a/src/main/java/flag_templates/GenericFlagTemplate.java
+++ b/src/main/java/flag_templates/GenericFlagTemplate.java
@@ -102,6 +102,7 @@ public class GenericFlagTemplate
         BufferedImage image = ImageIO.read(sourceFlagLocation);
         image = resizeImage(image,this.getBaseFlagWidth(),this.getBaseFlagHeight());
         convertToTGA(image,outputFolderLocation);
+		Desktop.getDesktop().open(new File(outputFileFolderPath));
     }
     public BufferedImage resizeImage(BufferedImage imageToResize, int width, int height)
     {


### PR DESCRIPTION
The directory in which the flag(s) are created is opened after the image creation in finished. Maybe some preference settings could be created and this could be enabled there instead of being by default, as maybe it could annoy a bit some users.